### PR TITLE
Fix typo in 3.4.1 (left injection should be right)

### DIFF
--- a/manuscript/chapter3.md
+++ b/manuscript/chapter3.md
@@ -287,7 +287,7 @@ For example, to prove distributivity of {$$}\land{/$$} with respect to {$$}\lor{
 
 ```
 f (x, left y)  = left (x, y)
-f (x, left y') = right (x, y')
+f (x, right y') = right (x, y')
 ```
 
 This notation (which is pretty similar to how we would write it in Idris) uses `(x, y)` to denote product type, that is, extract values from a product-type pair, and `left` and `right` to denote value constructors for sum type in order to extract values from a sum-type pair. In the next chapter we will introduce Idris and its syntax.


### PR DESCRIPTION
I think the left injection on the second line should be a right injection:
```
1 f (x, left y)  = left (x, y)
2 f (x, **left** y') = right (x, y')”
```